### PR TITLE
Restore PnL persistence dropped in the storage backend refactor

### DIFF
--- a/nexustrader/backends/db.py
+++ b/nexustrader/backends/db.py
@@ -54,6 +54,10 @@ class StorageBackend(ABC):
         pass
 
     @abstractmethod
+    async def sync_pnl(self, timestamp: int, pnl: float, unrealized_pnl: float) -> None:
+        pass
+
+    @abstractmethod
     def get_order(
         self,
         oid: str,

--- a/nexustrader/backends/db_postgresql.py
+++ b/nexustrader/backends/db_postgresql.py
@@ -218,6 +218,19 @@ class PostgreSQLBackend(StorageBackend):
                         str(amount.locked),
                     )
 
+    async def sync_pnl(self, timestamp: int, pnl: float, unrealized_pnl: float) -> None:
+        async with self._pg_async.acquire() as conn:
+            await conn.execute(
+                f"INSERT INTO {self.table_prefix}_pnl "
+                "(timestamp, pnl, unrealized_pnl) VALUES ($1, $2, $3) "
+                "ON CONFLICT (timestamp) DO UPDATE SET "
+                "pnl = EXCLUDED.pnl, "
+                "unrealized_pnl = EXCLUDED.unrealized_pnl",
+                int(timestamp),
+                float(pnl),
+                float(unrealized_pnl),
+            )
+
     def get_order(
         self,
         oid: str,

--- a/nexustrader/backends/db_sqlite.py
+++ b/nexustrader/backends/db_sqlite.py
@@ -217,6 +217,15 @@ class SQLiteBackend(StorageBackend):
                     )
             await self._db_async.commit()
 
+    async def sync_pnl(self, timestamp: int, pnl: float, unrealized_pnl: float) -> None:
+        async with self._db_async.cursor() as cursor:
+            await cursor.execute(
+                f"INSERT OR REPLACE INTO {self.table_prefix}_pnl "
+                "(timestamp, pnl, unrealized_pnl) VALUES (?, ?, ?)",
+                (timestamp, pnl, unrealized_pnl),
+            )
+            await self._db_async.commit()
+
     def get_order(
         self,
         oid: str,

--- a/nexustrader/core/cache.py
+++ b/nexustrader/core/cache.py
@@ -218,6 +218,10 @@ class AsyncCache:
     async def sync_params(self):
         await self._backend.sync_params(self._mem_params)
 
+    async def _sync_pnl(self, timestamp: int, pnl: float, unrealized_pnl: float):
+        """Persist a PnL snapshot; called periodically by MockLinearConnector."""
+        await self._backend.sync_pnl(timestamp, pnl, unrealized_pnl)
+
     def _cleanup_expired_data(self):
         """Cleanup expired data"""
         current_time = self._clock.timestamp_ms()

--- a/test/base/test_mock_linear_connector.py
+++ b/test/base/test_mock_linear_connector.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 from decimal import Decimal
 from typing import Dict
@@ -397,3 +399,69 @@ async def test_initialize_overwrite_check(
     assert (
         len(position) == 0
     )  # since we overwrite the balance, the position is not in db
+
+
+############################ TEST PNL PERSISTENCE ############################
+
+# Regression tests: the storage-backend refactor removed AsyncCache._sync_pnl
+# while MockLinearConnector still calls it from _handle_pnl_update() and
+# disconnect(), crashing mock trading sessions with AttributeError.
+
+
+async def test_pnl_snapshot_persisted_and_disconnect(
+    mock_linear_connector: MockLinearConnector,
+):
+    cache = mock_linear_connector._cache
+    await cache._init_storage()
+    await mock_linear_connector._init_balance()
+    await mock_linear_connector._init_position()
+
+    ts = _live_clock.timestamp_ms()
+    await cache._sync_pnl(ts, 10000.0, -25.5)
+    # Writing the same timestamp again must upsert on the PRIMARY KEY, not raise
+    await cache._sync_pnl(ts, 10001.0, -20.0)
+
+    cursor = cache._backend._get_cursor()
+    cursor.execute(
+        f"SELECT pnl, unrealized_pnl FROM {cache._backend.table_prefix}_pnl "
+        "WHERE timestamp = ?",
+        (ts,),
+    )
+    assert cursor.fetchall() == [(10001.0, -20.0)]
+
+    # disconnect() persists a final snapshot through the same path
+    await mock_linear_connector.disconnect()
+
+
+async def test_handle_pnl_update_survives_a_cycle(
+    exchange, task_manager, message_bus, cache
+):
+    connector = MockLinearConnector(
+        initial_balance={"USDT": 10000, "BTC": 0},
+        account_type=BinanceAccountType.LINEAR_MOCK,
+        exchange=exchange,
+        msgbus=message_bus,
+        clock=_live_clock,
+        cache=cache,
+        task_manager=task_manager,
+        overwrite_balance=True,
+        overwrite_position=True,
+        fee_rate=0.0005,
+        quote_currency="USDT",
+        update_interval=1,
+        leverage=1,
+    )
+    await cache._init_storage()
+    await connector._init_balance()
+    await connector._init_position()
+
+    task = asyncio.create_task(connector._handle_pnl_update())
+    await asyncio.sleep(1.2)  # let one update cycle (update_interval=1s) complete
+    try:
+        assert not task.done(), task.exception()
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass


### PR DESCRIPTION
Fixes #42

## Problem

The storage-backend refactor (070609b, #27) dropped `AsyncCache._sync_pnl()` while `MockLinearConnector` still calls it from `_handle_pnl_update()` and `disconnect()`. Any `MockConnectorConfig` (mock/paper trading) strategy crashes `update_interval` seconds after start:

```
AttributeError: 'AsyncCache' object has no attribute '_sync_pnl'
```

The `disconnect()` call raises again during `engine.dispose()`, aborting `_dispose()` before `cache.close()` runs, so the final orders/positions/balances sync is silently skipped. Both `SQLiteBackend` and `PostgreSQLBackend` still create the `{table_prefix}_pnl` table — only the write path was lost in the refactor.

## Changes

- `StorageBackend`: add `sync_pnl(timestamp, pnl, unrealized_pnl)` to the abstract interface
- `SQLiteBackend`: `INSERT OR REPLACE` the snapshot into the existing `{table_prefix}_pnl` table
- `PostgreSQLBackend`: `INSERT ... ON CONFLICT (timestamp) DO UPDATE` into the same table
- `AsyncCache`: restore `_sync_pnl()`, delegating to the backend — the `MockLinearConnector` call sites are unchanged
- Regression tests: PnL snapshots persist and upsert on timestamp conflicts, `_handle_pnl_update()` survives a full update cycle, and `disconnect()` completes

## Verification

- Red/green: before the fix the new tests fail with the exact production error above; after the fix `pytest test/` passes (221 passed, 8 skipped).
- End-to-end: ran a `MockConnectorConfig` strategy mirroring `strategy/binance/mock_trading.py` (`update_interval=20`) for 35 s, then SIGINT. The PnL task survives the 20 s mark, `{table_prefix}_pnl` receives the periodic snapshot plus the final snapshot written from `disconnect()`, and `engine.dispose()` completes without errors.
